### PR TITLE
RPM cleanup for Fedora and some changes to stability of the script

### DIFF
--- a/parsec-fedora
+++ b/parsec-fedora
@@ -1,7 +1,7 @@
 #!/bin/bash
-cd ~/
+cd ~/ || exit 1
 mkdir parsec_tmp
-cd parsec_tmp
+cd parsec_tmp || exit 1
 
 isopensuse=$(grep -q 'opensuse' /etc/os-release)
 if isopensuse -eq 0; then
@@ -26,7 +26,7 @@ else
   echo "Note: run 'sudo dnf remove alien rpmrebuild' if you don't want to keep those packages after install."
 fi
 
-cd ../
+cd ../ || exit 1
 rm -rf parsec_tmp
 echo "Now use parsecd in the terminal to start parsec."
 echo "Enjoy Gaming!"

--- a/parsec-fedora
+++ b/parsec-fedora
@@ -2,19 +2,29 @@
 cd ~/
 mkdir parsec_tmp
 cd parsec_tmp
-if cat /etc/os-release | grep -q 'opensuse'; then
+
+isopensuse=$(cat /etc/os-release | grep -q 'opensuse')
+if isopensuse -eq 0; then
   sudo zypper -n in debhelper
   wget http://download.opensuse.org/repositories/home:/Asukero/openSUSE_Tumbleweed/i586/alien-8.88-4.16.i586.rpm
   alien_file=$(ls alien*)
   yes | sudo rpm -i --force "${alien_file}"
 else
-  sudo dnf install alien
+  sudo dnf -y install alien rpmrebuild
 fi
+
 wget https://s3.amazonaws.com/parsec-build/package/parsec-linux.deb
 sudo alien -r parsec-linux.deb
-sudo rm -rf parsec-linux.deb
-parsec_file=$(ls parsec*)
-yes | sudo rpm -i --force "${parsec_file}" 
+parsec_file=$(ls parsec*.rpm)
+
+if isopensuse -eq 0; then
+    yes | sudo rpm -i --force "${parsec_file}"
+else
+  arch=$(uname -m)
+  rpmrebuild -p --change-spec-whole='sed  "/\"\/\"\|\"\/usr\"\|\"\/usr\/bin\"/d"' --directory=. "${parsec_file}"
+  sudo dnf -y install "${arch}"/"${parsec_file}"
+fi
+
 cd ../
 rm -rf parsec_tmp
 echo "Now use parsecd in the terminal to start parsec."

--- a/parsec-fedora
+++ b/parsec-fedora
@@ -3,7 +3,7 @@ cd ~/
 mkdir parsec_tmp
 cd parsec_tmp
 
-isopensuse=$(cat /etc/os-release | grep -q 'opensuse')
+isopensuse=$(grep -q 'opensuse' /etc/os-release)
 if isopensuse -eq 0; then
   sudo zypper -n in debhelper
   wget http://download.opensuse.org/repositories/home:/Asukero/openSUSE_Tumbleweed/i586/alien-8.88-4.16.i586.rpm

--- a/parsec-fedora
+++ b/parsec-fedora
@@ -23,6 +23,7 @@ else
   arch=$(uname -m)
   rpmrebuild -p --change-spec-whole='sed  "/\"\/\"\|\"\/usr\"\|\"\/usr\/bin\"/d"' --directory=. "${parsec_file}"
   sudo dnf -y install "${arch}"/"${parsec_file}"
+  echo "Note: run 'sudo dnf remove alien rpmrebuild' if you don't want to keep those packages after install."
 fi
 
 cd ../


### PR DESCRIPTION
Hi,  

Thanks for creating this script, I never considered converting .deb packages to rpm directly.
Since I dislike piping wget/curl output directly to bash, I've run the commands one by one and discovered there's some improvements I could make.  
Here's a list of changes:
* I've applied `rpmrebuild` package to clear up conflicts the converted package had with `filesystem` package on Fedora. After the change we're able to use more idiomatic `dnf` packager for installation instead of directly via `rpm`.
* Above required some control flow changes to the script, I've also added a note to Fedora users that they can safely remove `alien` and `rpmrebuild`.
* Rest of the commits are changes are general bash improvements (thanks to shellcheck):
  * Remove redundant cat command (we can directly grep a file)
  * Ensure the `cd` command runs in some freak accident where our directories are unavailable.

I haven't touched the Opensuse part of the script, since I don't have that system on hand for testing.
Let me know if you'd like to do anything different.